### PR TITLE
Screenshots

### DIFF
--- a/web_weaver/base_web_control.py
+++ b/web_weaver/base_web_control.py
@@ -60,7 +60,11 @@ class BaseWebControl:
         self._logger = logger.getChild(__name__)
         self._element = None
 
-    def find_element_by_id(self, value, timeout: int = 10, retries: int = 2):
+    def find_element_by_id(self,
+                           value,
+                           timeout: int = 10,
+                           retries: int = 2,
+                           screenshot_on_fail: bool = False):
         """
         Locate a web element by its HTML ``id`` attribute.
 
@@ -72,18 +76,26 @@ class BaseWebControl:
             Maximum number of seconds to wait for the element (default is 10).
         retries : int, optional
             Number of retries if the element reference becomes stale (default is 2).
+        screenshot_on_fail : bool, optional
+            If True, take a screenshot when the element cannot be found or
+            when all retries have been exhausted (default is False).
 
         Returns
         -------
         WebElement | None
             The located element, or None if not found.
         """
-        return self.__find_element(By.ID, value, timeout, retries)
+        return self.__find_element(By.ID,
+                                   value,
+                                   timeout,
+                                   retries,
+                                   screenshot_on_fail)
 
     def find_element_by_xpath(self,
                               value: str,
                               timeout: int = 10,
-                              retries: int = 2):
+                              retries: int = 2,
+                              screenshot_on_fail: bool = False):
         """
         Locate a web element using an XPath expression.
 
@@ -95,18 +107,26 @@ class BaseWebControl:
             Maximum number of seconds to wait for the element (default is 10).
         retries : int, optional
             Number of retries if the element reference becomes stale (default is 2).
+        screenshot_on_fail : bool, optional
+            If True, take a screenshot when the element cannot be found or
+            when all retries have been exhausted (default is False).
 
         Returns
         -------
         WebElement | None
             The located element, or None if not found.
         """
-        return self.__find_element(By.XPATH, value, timeout, retries)
+        return self.__find_element(By.XPATH,
+                                   value,
+                                   timeout,
+                                   retries,
+                                   screenshot_on_fail)
 
     def find_element_by_class_name(self,
                                    value: str,
                                    timeout: int = 10,
-                                   retries: int = 2):
+                                   retries: int = 2,
+                                   screenshot_on_fail: bool = False):
         """
         Locate a web element by its ``class`` attribute.
 
@@ -118,18 +138,26 @@ class BaseWebControl:
             Maximum number of seconds to wait for the element (default is 10).
         retries : int, optional
             Number of retries if the element reference becomes stale (default is 2).
+        screenshot_on_fail : bool, optional
+            If True, take a screenshot when the element cannot be found or
+            when all retries have been exhausted (default is False).
 
         Returns
         -------
         WebElement | None
             The located element, or None if not found.
         """
-        return self.__find_element(By.CLASS_NAME, value, timeout, retries)
+        return self.__find_element(By.CLASS_NAME,
+                                   value,
+                                   timeout,
+                                   retries,
+                                   screenshot_on_fail)
 
     def find_element_by_css(self,
                             value: str,
                             timeout: int = 10,
-                            retries: int = 2):
+                            retries: int = 2,
+                            screenshot_on_fail: bool = False):
         """
         Locate a web element using a CSS selector.
 
@@ -141,15 +169,27 @@ class BaseWebControl:
             Maximum number of seconds to wait for the element (default is 10).
         retries : int, optional
             Number of retries if the element reference becomes stale (default is 2).
+        screenshot_on_fail : bool, optional
+            If True, take a screenshot when the element cannot be found or
+            when all retries have been exhausted (default is False).
 
         Returns
         -------
         WebElement | None
             The located element, or None if not found.
         """
-        return self.__find_element(By.CSS_SELECTOR, value, timeout, retries)
+        return self.__find_element(By.CSS_SELECTOR,
+                                   value,
+                                   timeout,
+                                   retries,
+                                   screenshot_on_fail)
 
-    def __find_element(self, by, value, timeout: int, retries: int):
+    def __find_element(self,
+                       by,
+                       value,
+                       timeout: int,
+                       retries: int,
+                       screenshot_on_fail: bool):
         """
         Safely locate an element with retries and explicit wait.
 
@@ -169,6 +209,7 @@ class BaseWebControl:
         WebElement | None
             The located element, or None if not found.
         """
+        # pylint: disable=too-many-positional-arguments, too-many-arguments
         attempt = 0
 
         while attempt <= retries:
@@ -186,6 +227,10 @@ class BaseWebControl:
             except StaleElementReferenceException:
                 self._logger.warning(f"Stale element reference for {by}='{value}', retrying...")
                 attempt += 1
+
         self._logger.error(f"Failed to locate stable element after {retries} "
                            f"retries: {by}='{value}'")
+        if screenshot_on_fail:
+            filename = self._driver.take_screenshot(f"fail_{value}")
+            self._logger.info(f"Screenshot saved to {filename} due to failure")
         return None

--- a/web_weaver/main.py
+++ b/web_weaver/main.py
@@ -57,7 +57,8 @@ def main_full(test_textbox: bool = False,
               (WebDriverOption.DISABLE_NOTIFICATIONS,),
               (WebDriverOption.LOG_LEVEL, "3")]
 
-    wb = WebDriver(BrowserType.CHROME, parameters=params)
+    wb = WebDriver(BrowserType.CHROME, parameters=params,
+                   screenshots_enabled=True)
     print(f"WD is {wb.driver}")
 
     if test_textbox:
@@ -110,6 +111,8 @@ def main_full(test_textbox: bool = False,
         ms = MultiSelectDropdownControl(wb, logger)
         ms.find_element_by_xpath(multi)
         print("ALL Multi options: ", ms.get_all_options())
+
+        wb.take_screenshot()
 
         time.sleep(5)
         ms.select_by_value("volvo")

--- a/web_weaver/web_driver.py
+++ b/web_weaver/web_driver.py
@@ -55,14 +55,35 @@ class WebDriver:
                  screenshots_enabled: bool = False,
                  screenshots_dir: str = "screenshots"):
         """
-        Initialize the WebDriver for the specified browser.
+        Initialize a WebDriver instance for the specified browser, with optional
+        configuration for browser options and automatic screenshot management.
+
+        This constructor wraps Selenium WebDriver and uses `webdriver_manager`
+        to automatically download and configure the correct driver binary for
+        the selected browser.
 
         Args:
             browser_type (BrowserType, optional): The type of browser to launch.
-                Defaults to `BrowserType.CHROME`.
+                Supported values are `BrowserType.CHROME`, `BrowserType.FIREFOX`,
+                and `BrowserType.EDGE`. Defaults to `BrowserType.CHROME`.
+            parameters (List, optional): Optional list of browser-specific parameters
+                or options. These are parsed internally to configure the browser.
+            screenshots_enabled (bool, optional): Whether to enable automatic
+                screenshot capture. Defaults to False.
+            screenshots_dir (str, optional): Directory where screenshots will be
+                saved if `screenshots_enabled` is True. Defaults to `"screenshots"`.
 
         Raises:
-            ValueError: If the provided browser type is not supported.
+            ValueError: If an unsupported `browser_type` is provided.
+            RuntimeError: If the screenshots directory cannot be created due to
+                a filesystem error (e.g., permission issues or invalid path).
+
+        Notes:
+            - The WebDriver instance is stored in `self._driver` and can be used
+              for further Selenium operations.
+            - Screenshots are only saved if `screenshots_enabled` is True.
+            - The constructor ensures that the screenshots directory exists,
+              creating it if necessary.
         """
         self._screenshots_enabled: bool = screenshots_enabled
         self._screenshots_dir: str = screenshots_dir
@@ -87,7 +108,8 @@ class WebDriver:
         try:
             os.makedirs(self._screenshots_dir, exist_ok=True)
         except OSError as e:
-            raise RuntimeError(f"Failed to create screenshots directory: {e}")
+            raise RuntimeError(f"Failed to create screenshots directory: {e}") \
+                from e
 
     @property
     def driver(self):
@@ -115,6 +137,26 @@ class WebDriver:
             raise PageLoadError(url, e) from e
 
     def take_screenshot(self, name: str = "screenshot") -> str | None:
+        """
+        Capture a screenshot of the current browser window and save it to the
+        configured screenshots directory.
+
+        The filename will include the provided name and a timestamp to avoid
+        collisions, e.g., `screenshot_20250901_225430.png`.
+
+        Args:
+            name (str, optional): Base name for the screenshot file.
+                Defaults to `"screenshot"`.
+
+        Returns:
+            str | None: The full path to the saved screenshot file if screenshots
+            are enabled; otherwise, `None`.
+
+        Notes:
+            - Screenshots are only taken if `self._screenshots_enabled` is True.
+            - The screenshot is saved in PNG format in `self._screenshots_dir`.
+            - The method uses a timestamp in `YYYYMMDD_HHMMSS` format for uniqueness.
+        """
         if not self._screenshots_enabled:
             return None
 

--- a/web_weaver/web_driver.py
+++ b/web_weaver/web_driver.py
@@ -17,6 +17,7 @@ Copyright 2025 SwatKat1977
     You should have received a copy of the GNU General Public License
     along with this program.If not, see < https://www.gnu.org/licenses/>.
 """
+import os
 import typing
 from selenium.common.exceptions import WebDriverException
 from selenium import webdriver
@@ -49,7 +50,9 @@ class WebDriver:
 
     def __init__(self,
                  browser_type: BrowserType = BrowserType.CHROME,
-                 parameters: typing.Optional[typing.List] = None):
+                 parameters: typing.Optional[typing.List] = None,
+                 screenshots_enabled: bool = False,
+                 screenshots_dir: str = "screenshots"):
         """
         Initialize the WebDriver for the specified browser.
 
@@ -60,6 +63,9 @@ class WebDriver:
         Raises:
             ValueError: If the provided browser type is not supported.
         """
+        self._screenshots_enabled: bool = screenshots_enabled
+        self._screenshots_dir: str = screenshots_dir
+
         if browser_type == BrowserType.CHROME:
             options = self.__parse_options(parameters, browser_type)
             service = ChromeService(ChromeDriverManager().install())
@@ -76,6 +82,11 @@ class WebDriver:
 
         else:
             raise ValueError(f"Unsupported browser: {browser_type.value}")
+
+        try:
+            os.makedirs(self._screenshots_dir, exist_ok=True)
+        except OSError as e:
+            raise RuntimeError(f"Failed to create screenshots directory: {e}")
 
     @property
     def driver(self):

--- a/web_weaver/web_driver.py
+++ b/web_weaver/web_driver.py
@@ -18,6 +18,7 @@ Copyright 2025 SwatKat1977
     along with this program.If not, see < https://www.gnu.org/licenses/>.
 """
 import os
+import time
 import typing
 from selenium.common.exceptions import WebDriverException
 from selenium import webdriver
@@ -46,7 +47,7 @@ class WebDriver:
     Attributes:
         _driver (selenium.webdriver): The internal Selenium WebDriver instance.
     """
-    __slots__ = ["_driver"]
+    __slots__ = ["_driver", "_screenshots_dir", "_screenshots_enabled"]
 
     def __init__(self,
                  browser_type: BrowserType = BrowserType.CHROME,
@@ -112,6 +113,16 @@ class WebDriver:
             self._driver.get(url)
         except WebDriverException as e:
             raise PageLoadError(url, e) from e
+
+    def take_screenshot(self, name: str = "screenshot") -> str | None:
+        if not self._screenshots_enabled:
+            return None
+
+        timestamp: str = time.strftime("%Y%m%d_%H%M%S")
+        filename: str = os.path.join(self._screenshots_dir,
+                                     f"{name}_{timestamp}.png")
+        self._driver.save_screenshot(filename)
+        return filename
 
     def __parse_options(self,
                         parameters: list,


### PR DESCRIPTION
Added support for screenshots. A screenshot can be created by calling take_screenshot() from WebDriver. The name parameter is a prefix; a timestamp is then added to avoid clashes.

The find_element_xxx functions in base_web_control now take an extra optional parameter 'screenshot_on_fail', which allows screenshots to be taken if the element is not found (if screenshots are enabled in the driver).